### PR TITLE
Update ap2mal.py

### DIFF
--- a/ap2mal.py
+++ b/ap2mal.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #!/usr/bin/python
 #This script will take your anime-planet.com username and add your list to MAL using its API
 #Errors are output so you can enter those manually


### PR DESCRIPTION
This fixes a bug where the exception "SyntaxError: Non-ASCII character" would be thrown, which occurred when I attempted to run using Python 3.6.4 64-bit on Windows 10 build 16299.